### PR TITLE
Geen 'supra' bij rechtspraak

### DIFF
--- a/v-en-a.csl
+++ b/v-en-a.csl
@@ -893,6 +893,11 @@
                     <else-if type="book">
                         <text macro="book-note"/>
                     </else-if>
+                    <else-if>
+                        <if type="legal_case" match="any">
+                    	    <text macro="legal-case"/>
+                        </if>
+                    </else-if>
                     <else>
                         <text macro="author-note"/>
                         <choose>


### PR DESCRIPTION
Randnummer 115 V&A vraag om volledige verwijzing bij herhalingen van rechtspraak.
Supra dus niet voor rechtspraak, ibid wel.